### PR TITLE
Close files of engine logger

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -132,9 +132,11 @@ class Engine():
 
     def __exit__(self, exc_type, exc_value, tb):
         """
-        Allows the engine to be used as a context manager; simply stops the engine
-        if enabled.
+        Allows the engine to be used as a context manager
+        Stops the engine if enabled and closes loggers.
         """
+        for handler in self.logger.handlers:
+            handler.close()
         if self.enabled:
             self.shutdown_nfqueue()
 

--- a/engine.py
+++ b/engine.py
@@ -461,8 +461,7 @@ def main(args):
                 in_queue_num=args["in_queue_num"],
                 out_queue_num=args["out_queue_num"],
                 save_seen_packets=args["no_save_packets"],
-                demo_mode=args["demo_mode"]) as eng:
-        eng.initialize_nfqueue()
+                demo_mode=args["demo_mode"]):
 
         threading.Event().wait()  # Wait forever
 

--- a/engine.py
+++ b/engine.py
@@ -443,29 +443,26 @@ def main(args):
     """
     Kicks off the engine with the given arguments.
     """
-    try:
-        nat_config = {}
-        if args.get("sender_ip") and args.get("routing_ip") and args.get("forward_ip"):
-            nat_config = {"sender_ip" : args["sender_ip"],
-                          "routing_ip" : args["routing_ip"],
-                          "forward_ip" : args["forward_ip"]}
+    nat_config = {}
+    if args.get("sender_ip") and args.get("routing_ip") and args.get("forward_ip"):
+        nat_config = {"sender_ip": args["sender_ip"],
+                      "routing_ip": args["routing_ip"],
+                      "forward_ip": args["forward_ip"]}
 
-        eng = Engine(args["server_port"],
-                     args["strategy"],
-                     environment_id=args["environment_id"],
-                     server_side=args["server_side"],
-                     output_directory=args["output_directory"],
-                     forwarder=nat_config,
-                     log_level=args["log"],
-                     in_queue_num=args["in_queue_num"],
-                     out_queue_num=args["out_queue_num"],
-                     save_seen_packets=args["no_save_packets"],
-                     demo_mode=args["demo_mode"])
+    with Engine(args["server_port"],
+                args["strategy"],
+                environment_id=args["environment_id"],
+                server_side=args["server_side"],
+                output_directory=args["output_directory"],
+                forwarder=nat_config,
+                log_level=args["log"],
+                in_queue_num=args["in_queue_num"],
+                out_queue_num=args["out_queue_num"],
+                save_seen_packets=args["no_save_packets"],
+                demo_mode=args["demo_mode"]) as eng:
         eng.initialize_nfqueue()
-        while True:
-            time.sleep(0.5)
-    finally:
-        eng.shutdown_nfqueue()
+
+        threading.Event().wait()  # Wait forever
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When running evolve.py the file descriptors for the individual logfiles of all started engine instances are not closed on exit of the instance. The open files can be viewed with `ls -l /proc/<pid OR "self">/fd/`.

This makes the engine collect hundreds of open files. The default limit is 1024 (`ulimit -n`) after which evolve.py (`python evolve.py --test-type http --port 80 --log debug`) crashes with 
```
OSError: [Errno 24] Too many open files
Traceback (most recent call last):
  File "/home/vagrant/geneva/evolve.py", line 835, in <module>
    driver(sys.argv[1:])
  File "/home/vagrant/geneva/evolve.py", line 814, in driver
    hall_of_fame = genetic_solve(logger, options, ga_evaluator)
  File "/home/vagrant/geneva/evolve.py", line 552, in genetic_solve
    offspring = fitness_function(logger, offspring, ga_evaluator)
  File "/home/vagrant/geneva/evolve.py", line 207, in fitness_function
    return ga_evaluator.evaluate(population)
  File "/home/vagrant/geneva/evaluator.py", line 184, in evaluate
    self.worker(ind_list, "main", environment)
  File "/home/vagrant/geneva/evaluator.py", line 808, in worker
    eid, fitness = self.run_test(environment, ind)
  File "/home/vagrant/geneva/evaluator.py", line 239, in run_test
    self.plugin.start(self.args, self, environment, ind, self.logger)
  File "/home/vagrant/geneva/plugins/http/plugin.py", line 143, in start
    fitness = evaluator.run_client(evaluator.client_args, environment, logger)
  File "/home/vagrant/geneva/evaluator.py", line 301, in run_client
    self.run_local_client(args, environment, logger)
  File "/home/vagrant/geneva/evaluator.py", line 481, in run_local_client
    self.exec_cmd(command)
  File "/home/vagrant/geneva/evaluator.py", line 494, in exec_cmd
    subprocess.check_call(command, timeout=60)
  File "/usr/lib/python3.9/subprocess.py", line 368, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/lib/python3.9/subprocess.py", line 349, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.9/subprocess.py", line 1722, in _execute_child
    errpipe_read, errpipe_write = os.pipe()
OSError: [Errno 24] Too many open files
```

This PR fixes this by employing the context manager in the main method and closing the logging handler upon exit.