### PR TITLE
Optimizing RUN commands and adding Debian Stretch Archive

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM python:3.6-stretch
 # Set the root password in the container so we can use it
 RUN echo "root:Docker!" | chpasswd
-RUN apt-get -y update
-RUN apt-get -y install libnetfilter-queue-dev iptables tcpdump netcat net-tools git graphviz openssh-server
+
+ENV PATH="/usr/sbin:${PATH}"
+RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
+RUN apt-get -y update && \
+    apt-get -y install libnetfilter-queue-dev iptables tcpdump netcat net-tools git graphviz openssh-server && \
+    pip install netfilterqueue requests dnspython anytree graphviz netifaces paramiko tld docker scapy==2.4.3 psutil && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install tshark
+
 # Enable root SSH login for client testing
 RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
@@ -10,8 +16,4 @@ RUN sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install tshark
-ENV PATH="/usr/sbin:${PATH}"
-RUN pip install netfilterqueue requests dnspython anytree graphviz netifaces paramiko tld docker scapy==2.4.3 psutil
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Currently, when trying to build the Docker image, errors related to Debian stretch packages being removed from the main repos ([1](https://unix.stackexchange.com/a/371907)) are generated. Adding the archive subdomain in this Dockerfile fixes the bug. 

The errors can be seen below:

```
Err:10 http://deb.debian.org/debian stretch/main amd64 Packages
  404  Not Found
Ign:11 http://deb.debian.org/debian stretch-updates/main all Packages
Err:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
  404  Not Found
Reading package lists...
W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get -y update' returned a non-zero code: 100
```

Additionally, the RUN commands are optimized to follow Docker best practices ([2](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)).